### PR TITLE
Fix: 승부예측 하위 페이지 메타데이터(타이틀) 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,7 @@ import { ReactNode } from "react";
 import "@/styles/GlobalStyles.scss";
 
 export const metadata: Metadata = {
-  title: "승리요정",
-  description: "승리요정",
+  title: "플레이닷",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/src/app/match/month/page.tsx
+++ b/src/app/match/month/page.tsx
@@ -1,4 +1,8 @@
-"use client";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "플레이닷 | 월간 승리요정",
+};
 
 function MonthPage() {
   return (

--- a/src/app/match/previous/page.tsx
+++ b/src/app/match/previous/page.tsx
@@ -1,3 +1,9 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "플레이닷 | 지난 예측",
+};
+
 function PreviousPage() {
   return <div>지난예측</div>;
 }

--- a/src/app/match/today/page.tsx
+++ b/src/app/match/today/page.tsx
@@ -1,7 +1,10 @@
-"use client";
-
 import DateSection from "@/components/today/DateSection";
 import ScoreBoard from "@/components/today/ScoreBoard";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "플레이닷 | 오늘의 승부예측",
+};
 
 function TodayPage() {
   return (


### PR DESCRIPTION
### 📌 개요

<!-- PR과 관련있는 Issue를 closed 해주세요 -->

closed #7

작업한 내용에 대해 간단히 작성해주세요.

### ✅ 작업내용

- 승부예측 하위 페이지 타이틀 적용
- 현재 dynamic metadata 적용 시 오류 발생 -> 추후 문제해결 후 적용 예정

### 📝 공유사항

팀원들에게 공유할 사항이나 변경 사항들을 작성해주세요.

- 메타데이터 적극적으로 활용해주세요! (공식문서 -> 페이지 내부에 head 권장 X)
