### PR TITLE
[Feature] Signup 단계별 ui 개발

### DIFF
--- a/public/images/signupIcon.svg
+++ b/public/images/signupIcon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="90" height="90" viewBox="0 0 90 90" fill="none">
+<circle cx="45" cy="45" r="45" fill="#2F3134"/>
+<path d="M45 30V60" stroke="#45484D" stroke-width="2"/>
+<path d="M60 45L30 45" stroke="#45484D" stroke-width="2"/>
+</svg>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,12 @@
+import SignupSection from "@/components/signup/SignupSection";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "플레이닷 | 회원가입",
+};
+
+function SignupPage() {
+  return <SignupSection />;
+}
+
+export default SignupPage;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -58,7 +58,8 @@ function Header() {
         </div>
         {pathname === "/community" ||
           pathname === "/match/chat" ||
-          pathname === "/login" || <SubMenu />}
+          pathname === "/login" ||
+          pathname === "/signup" || <SubMenu />}
       </header>
       <div className="space" />
     </>

--- a/src/components/signup/Buttons/SignupButtons.scss
+++ b/src/components/signup/Buttons/SignupButtons.scss
@@ -1,0 +1,10 @@
+.button-block {
+  width: 142px;
+  height: 75px;
+  border-radius: 16px;
+  background: #292b2e;
+  color: white;
+  border: none;
+  font-size: 22px;
+  cursor: pointer;
+}

--- a/src/components/signup/Buttons/SignupButtons.tsx
+++ b/src/components/signup/Buttons/SignupButtons.tsx
@@ -1,0 +1,11 @@
+import "@/Components/signup/Buttons/SignupButtons.scss";
+
+interface TextProps {
+  title: string;
+}
+
+function SignupButtons({ title }: TextProps) {
+  return <button className="button-block">{title}</button>;
+}
+
+export default SignupButtons;

--- a/src/components/signup/Buttons/SignupButtons.tsx
+++ b/src/components/signup/Buttons/SignupButtons.tsx
@@ -1,11 +1,19 @@
+"use client";
+
+import useStore from "@/lib/store/signup/store";
 import "@/Components/signup/Buttons/SignupButtons.scss";
 
 interface TextProps {
   title: string;
+  onClick: (_e?: React.MouseEvent<HTMLElement>) => void;
 }
 
-function SignupButtons({ title }: TextProps) {
-  return <button className="button-block">{title}</button>;
+function SignupButtons({ title, onClick }: TextProps) {
+  return (
+    <button className="button-block" onClick={onClick}>
+      {title}
+    </button>
+  );
 }
 
 export default SignupButtons;

--- a/src/components/signup/SignupSection.scss
+++ b/src/components/signup/SignupSection.scss
@@ -8,12 +8,21 @@
   justify-content: center;
   align-items: center;
   margin-bottom: 152px;
+
+  &__buttons {
+    width: 100%;
+    padding: 54px 70px;
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+  }
+
   &__intro {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    margin: 92px 0 70px 0;
+    margin-bottom: 70px;
     &__circles {
       background-color: rgba(255, 255, 255, 0.2);
       border-radius: 50%;

--- a/src/components/signup/SignupSection.scss
+++ b/src/components/signup/SignupSection.scss
@@ -7,6 +7,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  margin-bottom: 152px;
   &__intro {
     display: flex;
     flex-direction: column;

--- a/src/components/signup/SignupSection.scss
+++ b/src/components/signup/SignupSection.scss
@@ -1,0 +1,41 @@
+@import "@/styles/colors.scss";
+
+.signup-block {
+  color: $dark-text2;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  &__intro {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin: 92px 0 70px 0;
+    &__content {
+      margin-top: 25px;
+      text-align: center;
+      line-height: 34px;
+      color: $login-text;
+    }
+    &__circles {
+      background-color: rgba(255, 255, 255, 0.2);
+      border-radius: 50%;
+      width: 64px;
+      height: 64px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-size: 40px;
+      font-family: Pretendard;
+      margin-bottom: 42px;
+    }
+  }
+  .teamcards-block {
+    width: 1200px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+  }
+}

--- a/src/components/signup/SignupSection.scss
+++ b/src/components/signup/SignupSection.scss
@@ -13,12 +13,6 @@
     justify-content: center;
     align-items: center;
     margin: 92px 0 70px 0;
-    &__content {
-      margin-top: 25px;
-      text-align: center;
-      line-height: 34px;
-      color: $login-text;
-    }
     &__circles {
       background-color: rgba(255, 255, 255, 0.2);
       border-radius: 50%;
@@ -29,13 +23,6 @@
       align-items: center;
       font-size: 40px;
       font-family: Pretendard;
-      margin-bottom: 42px;
     }
-  }
-  .teamcards-block {
-    width: 1200px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px;
   }
 }

--- a/src/components/signup/SignupSection.tsx
+++ b/src/components/signup/SignupSection.tsx
@@ -5,12 +5,33 @@ import "@/components/signup/SignupSection.scss";
 import useStore from "@/lib/store/signup/store";
 import SignupStepOne from "@/components/signup/SignupStepOne";
 import SignupStepTwo from "@/components/signup/SignupStepTwo";
+import SignupButtons from "./Buttons/SignupButtons";
 
 function SignupSection() {
-  const { signUpStep } = useStore();
+  const { signUpStep, increaseStep, decreaseStep } = useStore();
+
+  const handleOnclickNextButton = () => {
+    increaseStep();
+  };
+  const handleOnclickPreviousButton = () => {
+    decreaseStep();
+  };
 
   return (
     <section className="signup-block">
+      <div className="signup-block__buttons">
+        {signUpStep === 1 ? (
+          <SignupButtons title={"다음"} onClick={handleOnclickNextButton} />
+        ) : (
+          <>
+            <SignupButtons title={"다음"} onClick={handleOnclickNextButton} />
+            <SignupButtons
+              title={"이전"}
+              onClick={handleOnclickPreviousButton}
+            />
+          </>
+        )}
+      </div>
       <div className="signup-block__intro">
         <div className="signup-block__intro__circles">{signUpStep}</div>
       </div>

--- a/src/components/signup/SignupSection.tsx
+++ b/src/components/signup/SignupSection.tsx
@@ -14,8 +14,7 @@ function SignupSection() {
       <div className="signup-block__intro">
         <div className="signup-block__intro__circles">{signUpStep}</div>
       </div>
-      <SignupStepOne />
-      <SignupStepTwo />
+      {signUpStep === 1 ? <SignupStepOne /> : <SignupStepTwo />}
     </section>
   );
 }

--- a/src/components/signup/SignupSection.tsx
+++ b/src/components/signup/SignupSection.tsx
@@ -1,11 +1,24 @@
+import "@/components/signup/SignupSection.scss";
+import SignupTeamCards from "./SignupTeamCards";
+import { TEAMS_INFO } from "./TeamsInfo";
+import Title from "@/components/common/Title";
+
 function SignupSection() {
   return (
-    <section>
-      <h1>나의 구단 선택하기</h1>
-      <p>
-        내가 응원하는 구단을 골라주세요! 팀 뱃지를 부여받고 커뮤니티에서 소통할
-        수 있어요.
-      </p>
+    <section className="signup-block">
+      <div className="signup-block__intro">
+        <div className="signup-block__intro__circles">1</div>
+        <Title largest>나의 구단 선택하기</Title>
+        <Title small className="signup-block__intro__content">
+          내가 응원하는 구단을 골라주세요!
+          <br />팀 뱃지를 부여받고 커뮤니티에서 소통할 수 있어요.
+        </Title>
+      </div>
+      <div className="teamcards-block">
+        {TEAMS_INFO.map((team) => (
+          <SignupTeamCards key={team.name} {...team} />
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/components/signup/SignupSection.tsx
+++ b/src/components/signup/SignupSection.tsx
@@ -1,24 +1,19 @@
+"use client";
+
 import "@/components/signup/SignupSection.scss";
-import SignupTeamCards from "./SignupTeamCards";
-import { TEAMS_INFO } from "./TeamsInfo";
-import Title from "@/components/common/Title";
+
+import useStore from "@/lib/store/signup/store";
+import SignupStepOne from "@/components/signup/SignupStepOne";
 
 function SignupSection() {
+  const { signUpStep } = useStore();
+
   return (
     <section className="signup-block">
       <div className="signup-block__intro">
-        <div className="signup-block__intro__circles">1</div>
-        <Title largest>나의 구단 선택하기</Title>
-        <Title small className="signup-block__intro__content">
-          내가 응원하는 구단을 골라주세요!
-          <br />팀 뱃지를 부여받고 커뮤니티에서 소통할 수 있어요.
-        </Title>
+        <div className="signup-block__intro__circles">{signUpStep}</div>
       </div>
-      <div className="teamcards-block">
-        {TEAMS_INFO.map((team) => (
-          <SignupTeamCards key={team.name} {...team} />
-        ))}
-      </div>
+      <SignupStepOne />
     </section>
   );
 }

--- a/src/components/signup/SignupSection.tsx
+++ b/src/components/signup/SignupSection.tsx
@@ -4,6 +4,7 @@ import "@/components/signup/SignupSection.scss";
 
 import useStore from "@/lib/store/signup/store";
 import SignupStepOne from "@/components/signup/SignupStepOne";
+import SignupStepTwo from "@/components/signup/SignupStepTwo";
 
 function SignupSection() {
   const { signUpStep } = useStore();
@@ -14,6 +15,7 @@ function SignupSection() {
         <div className="signup-block__intro__circles">{signUpStep}</div>
       </div>
       <SignupStepOne />
+      <SignupStepTwo />
     </section>
   );
 }

--- a/src/components/signup/SignupSection.tsx
+++ b/src/components/signup/SignupSection.tsx
@@ -1,0 +1,13 @@
+function SignupSection() {
+  return (
+    <section>
+      <h1>나의 구단 선택하기</h1>
+      <p>
+        내가 응원하는 구단을 골라주세요! 팀 뱃지를 부여받고 커뮤니티에서 소통할
+        수 있어요.
+      </p>
+    </section>
+  );
+}
+
+export default SignupSection;

--- a/src/components/signup/SignupStepOne.scss
+++ b/src/components/signup/SignupStepOne.scss
@@ -1,0 +1,16 @@
+@import "@/styles/colors.scss";
+
+.content {
+  margin-top: 25px;
+  text-align: center;
+  line-height: 34px;
+  color: $login-text;
+}
+
+.teamcards-block {
+  margin-top: 80px;
+  width: 1200px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}

--- a/src/components/signup/SignupStepOne.scss
+++ b/src/components/signup/SignupStepOne.scss
@@ -1,16 +1,21 @@
 @import "@/styles/colors.scss";
 
-.content {
-  margin-top: 25px;
+.stepOne__block {
   text-align: center;
-  line-height: 34px;
-  color: $login-text;
-}
 
-.teamcards-block {
-  margin-top: 80px;
-  width: 1200px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
+  &--title {
+    color: $login-text;
+  }
+  &--text {
+    line-height: 34px;
+    margin-top: 25px;
+    color: $login-text;
+  }
+  .teamcards-block {
+    margin-top: 80px;
+    width: 1200px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+  }
 }

--- a/src/components/signup/SignupStepOne.tsx
+++ b/src/components/signup/SignupStepOne.tsx
@@ -11,8 +11,8 @@ function SignupStepOne() {
         나의 구단 선택하기
       </Title>
       <Title small className="content">
-        내가 응원하는 구단을 골라주세요!
-        <br />팀 뱃지를 부여받고 커뮤니티에서 소통할 수 있어요.
+        응원하는 구단을 골라줘!
+        <br />팀 뱃지를 부여받고 커뮤니티에서 소통할 수 있어.
       </Title>
       <div className="teamcards-block">
         {TEAMS_INFO.map((team) => (

--- a/src/components/signup/SignupStepOne.tsx
+++ b/src/components/signup/SignupStepOne.tsx
@@ -1,0 +1,26 @@
+import "@/components/signup/SignupStepOne.scss";
+
+import Title from "@/components/common/Title";
+import SignupTeamCards from "@/components/signup/SignupTeamCards";
+import { TEAMS_INFO } from "./TeamsInfo";
+
+function SignupStepOne() {
+  return (
+    <div>
+      <Title largest className="content">
+        나의 구단 선택하기
+      </Title>
+      <Title small className="content">
+        내가 응원하는 구단을 골라주세요!
+        <br />팀 뱃지를 부여받고 커뮤니티에서 소통할 수 있어요.
+      </Title>
+      <div className="teamcards-block">
+        {TEAMS_INFO.map((team) => (
+          <SignupTeamCards key={team.name} {...team} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default SignupStepOne;

--- a/src/components/signup/SignupStepOne.tsx
+++ b/src/components/signup/SignupStepOne.tsx
@@ -6,11 +6,11 @@ import { TEAMS_INFO } from "./TeamsInfo";
 
 function SignupStepOne() {
   return (
-    <div>
-      <Title largest className="content">
+    <div className="stepOne__block">
+      <Title largest className="stepOne__block--title">
         나의 구단 선택하기
       </Title>
-      <Title small className="content">
+      <Title small className="stepOne__block--text">
         응원하는 구단을 골라줘!
         <br />팀 뱃지를 부여받고 커뮤니티에서 소통할 수 있어.
       </Title>

--- a/src/components/signup/SignupStepTwo.scss
+++ b/src/components/signup/SignupStepTwo.scss
@@ -1,11 +1,13 @@
+@import "@/styles/colors.scss";
+
 @mixin container-style {
   box-sizing: border-box;
   font-size: 22px;
   border-radius: 16px;
-  background: #292b2e;
+  background: $signup-back;
   border: none;
   resize: none;
-  color: white;
+  color: $dark-text2;
 }
 
 .stepTwo-block {
@@ -32,8 +34,8 @@
         width: 285px;
         height: 350px;
         border-radius: 20px;
-        background: #292b2e;
-        border: 2px solid #45484d;
+        background: $signup-back;
+        border: 2px solid $signup-border;
 
         img {
           width: 90px;

--- a/src/components/signup/SignupStepTwo.scss
+++ b/src/components/signup/SignupStepTwo.scss
@@ -1,0 +1,10 @@
+.upload {
+  width: 285px;
+  height: 350px;
+  border-radius: 20px;
+  background: #292b2e;
+  border: 2px solid #45484d;
+}
+.stepTwo-content {
+  display: flex;
+}

--- a/src/components/signup/SignupStepTwo.scss
+++ b/src/components/signup/SignupStepTwo.scss
@@ -1,10 +1,97 @@
-.upload {
-  width: 285px;
-  height: 350px;
-  border-radius: 20px;
+@mixin container-style {
+  box-sizing: border-box;
+  font-size: 22px;
+  border-radius: 16px;
   background: #292b2e;
-  border: 2px solid #45484d;
+  border: none;
+  resize: none;
+  color: white;
 }
-.stepTwo-content {
-  display: flex;
+
+.stepTwo-block {
+  width: 1200px;
+  text-align: center;
+
+  &__text {
+    margin-top: 25px;
+  }
+
+  .stepTwo-content {
+    display: flex;
+    gap: 30px;
+    margin-top: 152px;
+
+    &__cards {
+      display: flex;
+      gap: 31px;
+
+      .cards__upload {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 285px;
+        height: 350px;
+        border-radius: 20px;
+        background: #292b2e;
+        border: 2px solid #45484d;
+
+        img {
+          width: 90px;
+          height: 90px;
+        }
+
+        .cards__input {
+          display: none;
+        }
+      }
+    }
+
+    &__info {
+      width: 568px;
+      justify-content: space-between;
+
+      .info-content {
+        display: flex;
+        flex-direction: column;
+
+        &__nickname {
+          width: 100%;
+          display: flex;
+          justify-content: space-between;
+          margin-bottom: 32px;
+
+          .nickname__input {
+            @include container-style;
+            width: 380px;
+            height: 75px;
+            padding-left: 29px;
+            &:focus {
+              outline: none;
+            }
+          }
+          .nickname__button {
+            @include container-style;
+            cursor: pointer;
+            width: 142px;
+            height: 75px;
+          }
+        }
+
+        .words__input {
+          @include container-style;
+          font-family: "pretendard";
+          height: 157px;
+          padding: 22px 29px;
+          &:focus {
+            outline: none;
+          }
+        }
+      }
+    }
+
+    &__title {
+      text-align: left;
+      margin-bottom: 14px;
+    }
+  }
 }

--- a/src/components/signup/SignupStepTwo.tsx
+++ b/src/components/signup/SignupStepTwo.tsx
@@ -8,24 +8,30 @@ import { TEAMS_INFO } from "./TeamsInfo";
 
 function SignupStepTwo() {
   return (
-    <div>
+    <div className="stepTwo-block">
       <Title largest className="content">
         프로필 설정하기
       </Title>
       <Title small className="content">
         나만의 프로필을 만들어봐!
       </Title>
-      <div className="teamcards-block">
+      <div className="stepTwo-content">
         <SignupTeamCards {...TEAMS_INFO[1]} />
-      </div>
-      <div>
-        <Text>닉네임</Text>
-        <input type="text" />
-        <button>중복확인</button>
-      </div>
-      <div>
-        <Text>한마디</Text>
-        <textarea></textarea>
+        <div className="upload">
+          <div></div>
+          <input type="file" accept="image/*" />
+        </div>
+        <div>
+          <div>
+            <Text>닉네임</Text>
+            <input type="text" />
+            <button>중복확인</button>
+          </div>
+          <div>
+            <Text>한마디</Text>
+            <textarea></textarea>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/signup/SignupStepTwo.tsx
+++ b/src/components/signup/SignupStepTwo.tsx
@@ -1,7 +1,7 @@
-import "@/components/signup/SignupStepTwo.scss";
+import Image from "next/image";
 
+import "@/components/signup/SignupStepTwo.scss";
 import Title from "@/components/common/Title";
-import Text from "@/components/common/Text";
 
 import SignupTeamCards from "@/components/signup/SignupTeamCards";
 import { TEAMS_INFO } from "./TeamsInfo";
@@ -9,27 +9,47 @@ import { TEAMS_INFO } from "./TeamsInfo";
 function SignupStepTwo() {
   return (
     <div className="stepTwo-block">
-      <Title largest className="content">
+      <Title largest className="stepTwo-block__title">
         프로필 설정하기
       </Title>
-      <Title small className="content">
+      <Title small className="stepTwo-block__text">
         나만의 프로필을 만들어봐!
       </Title>
       <div className="stepTwo-content">
-        <SignupTeamCards {...TEAMS_INFO[1]} />
-        <div className="upload">
-          <div></div>
-          <input type="file" accept="image/*" />
-        </div>
-        <div>
-          <div>
-            <Text>닉네임</Text>
-            <input type="text" />
-            <button>중복확인</button>
+        <div className="stepTwo-content__cards">
+          <SignupTeamCards {...TEAMS_INFO[1]} />
+          <div className="cards__upload">
+            <Image
+              src={"/images/signupIcon.svg"}
+              alt={"plusIcon"}
+              width={0}
+              height={0}
+            />
+            <input type="file" accept="image/*" className="cards__input" />
           </div>
-          <div>
-            <Text>한마디</Text>
-            <textarea></textarea>
+        </div>
+        <div className="stepTwo-content__info">
+          <div className="info-content">
+            <Title small className="stepTwo-content__title">
+              닉네임
+            </Title>
+            <div className="info-content__nickname">
+              <input
+                type="text"
+                className="nickname__input"
+                placeholder="닉네임을 입력해줘!"
+              />
+              <button className="nickname__button">중복확인</button>
+            </div>
+          </div>
+          <div className="info-content">
+            <Title small className="stepTwo-content__title">
+              한마디
+            </Title>
+            <textarea
+              className="words__input"
+              placeholder="한마디를 입력해줘!"
+            ></textarea>
           </div>
         </div>
       </div>

--- a/src/components/signup/SignupStepTwo.tsx
+++ b/src/components/signup/SignupStepTwo.tsx
@@ -1,0 +1,34 @@
+import "@/components/signup/SignupStepTwo.scss";
+
+import Title from "@/components/common/Title";
+import Text from "@/components/common/Text";
+
+import SignupTeamCards from "@/components/signup/SignupTeamCards";
+import { TEAMS_INFO } from "./TeamsInfo";
+
+function SignupStepTwo() {
+  return (
+    <div>
+      <Title largest className="content">
+        프로필 설정하기
+      </Title>
+      <Title small className="content">
+        나만의 프로필을 만들어봐!
+      </Title>
+      <div className="teamcards-block">
+        <SignupTeamCards {...TEAMS_INFO[1]} />
+      </div>
+      <div>
+        <Text>닉네임</Text>
+        <input type="text" />
+        <button>중복확인</button>
+      </div>
+      <div>
+        <Text>한마디</Text>
+        <textarea></textarea>
+      </div>
+    </div>
+  );
+}
+
+export default SignupStepTwo;

--- a/src/components/signup/SignupTeamCards.scss
+++ b/src/components/signup/SignupTeamCards.scss
@@ -1,0 +1,44 @@
+.teamcard-block {
+  position: relative;
+  width: 285px;
+  height: 350px;
+  border-radius: 20px;
+  border: 2px solid #fff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 0;
+  cursor: pointer;
+  overflow: hidden;
+
+  .teamname {
+    position: relative;
+    z-index: 9;
+    font-size: 30px;
+  }
+
+  img {
+    position: relative;
+    z-index: 9;
+    width: 216px;
+    height: 350px;
+  }
+
+  &__backgrounds {
+    position: absolute;
+    bottom: 40px;
+    z-index: 1;
+    display: flex;
+    transform: rotate(45deg);
+
+    .square {
+      width: 150px;
+      height: 450px;
+      background-color: cadetblue;
+      &:last-child {
+        width: 40px;
+      }
+    }
+  }
+}

--- a/src/components/signup/SignupTeamCards.scss
+++ b/src/components/signup/SignupTeamCards.scss
@@ -1,44 +1,102 @@
+@import "@/styles/colors.scss";
+
 .teamcard-block {
   position: relative;
   width: 285px;
   height: 350px;
-  border-radius: 20px;
-  border: 2px solid #fff;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 40px 0;
-  cursor: pointer;
-  overflow: hidden;
 
-  .teamname {
+  .teamcard-content {
+    border-radius: 20px;
+    height: 100%;
     position: relative;
-    z-index: 9;
-    font-size: 30px;
-  }
-
-  img {
-    position: relative;
-    z-index: 9;
-    width: 216px;
-    height: 350px;
-  }
-
-  &__backgrounds {
-    position: absolute;
-    bottom: 40px;
-    z-index: 1;
+    border: 2px solid #fff;
     display: flex;
-    transform: rotate(45deg);
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 0;
+    cursor: pointer;
+    overflow: hidden;
 
-    .square {
-      width: 150px;
-      height: 450px;
-      background-color: cadetblue;
-      &:last-child {
-        width: 40px;
+    &--active {
+      width: 100%;
+      position: absolute;
+      border: none;
+      background: $main;
+      z-index: 99;
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+
+    &--active:hover {
+      opacity: 0.9;
+    }
+
+    &__backgrounds {
+      position: absolute;
+      bottom: 90px;
+      left: 60px;
+      z-index: 1;
+      display: flex;
+      transform: rotate(45deg);
+      .square {
+        width: 150px;
+        height: 450px;
       }
+      .first-square {
+        margin-top: 80px;
+      }
+      .second-square {
+        margin-top: -20px;
+      }
+      .third-square {
+        width: 40px;
+        margin-top: -12px;
+        opacity: 0.2;
+      }
+      .square--lions {
+        background: linear-gradient(#fff 20%, $lions1 75%, rgba(1, 1, 1, 0));
+      }
+      .square--twins {
+        background: linear-gradient(#fff 20%, $twins1 75%, rgba(1, 1, 1, 0));
+      }
+      .square--tigers {
+        background: linear-gradient(#fff 20%, $tigers1 75%, rgba(1, 1, 1, 0));
+      }
+      .square--giants {
+        background: linear-gradient(#fff 20%, $gients3 75%, rgba(1, 1, 1, 0));
+      }
+      .square--eagles {
+        background: linear-gradient(#fff 20%, $eagles1 75%, rgba(1, 1, 1, 0));
+      }
+      .square--heroes {
+        background: linear-gradient(#fff 20%, $heroes1 75%, rgba(1, 1, 1, 0));
+      }
+      .square--landers {
+        background: linear-gradient(#fff 20%, $landers1 75%, rgba(1, 1, 1, 0));
+      }
+      .square--bears {
+        background: linear-gradient(#fff 20%, blue 75%, rgba(1, 1, 1, 0));
+      }
+      .square--dinos {
+        background: linear-gradient(#fff 20%, $dinos2 75%, rgba(1, 1, 1, 0));
+      }
+      .square--wiz {
+        background: linear-gradient(#fff 20%, gray 75%, rgba(1, 1, 1, 0));
+      }
+    }
+
+    .teamname {
+      position: relative;
+      z-index: 9;
+      font-size: 30px;
+    }
+
+    img {
+      position: relative;
+      z-index: 9;
+      width: 216px;
+      height: 350px;
     }
   }
 }

--- a/src/components/signup/SignupTeamCards.tsx
+++ b/src/components/signup/SignupTeamCards.tsx
@@ -1,0 +1,18 @@
+import Image from "next/image";
+import "@/components/signup/SignupTeamCards.scss";
+
+function SignupTeamCards(team: any) {
+  return (
+    <div className="teamcard-block">
+      <Image src={team.img} alt={team.name} width={0} height={0} />
+      <p className="teamname">{team.name}</p>
+      <div className="teamcard-block__backgrounds">
+        <div className="square"></div>
+        <div className="square"></div>
+        <div className="square"></div>
+      </div>
+    </div>
+  );
+}
+
+export default SignupTeamCards;

--- a/src/components/signup/SignupTeamCards.tsx
+++ b/src/components/signup/SignupTeamCards.tsx
@@ -1,15 +1,46 @@
+import React from "react";
 import Image from "next/image";
+import classNames from "classnames";
 import "@/components/signup/SignupTeamCards.scss";
 
-function SignupTeamCards(team: any) {
+interface TeamProps {
+  img: string;
+  name: string;
+  color: string;
+}
+
+function SignupTeamCards(team: TeamProps) {
   return (
     <div className="teamcard-block">
-      <Image src={team.img} alt={team.name} width={0} height={0} />
-      <p className="teamname">{team.name}</p>
-      <div className="teamcard-block__backgrounds">
-        <div className="square"></div>
-        <div className="square"></div>
-        <div className="square"></div>
+      <div className="teamcard-content teamcard-content--active">
+        <p className="teamname">선택하기</p>
+      </div>
+      <div className="teamcard-content">
+        <Image src={team.img} alt={team.name} width={0} height={0} />
+        <p className="teamname">{team.name}</p>
+        <div className="teamcard-content__backgrounds">
+          <div
+            className={classNames(
+              "square",
+              "first-square",
+              `square--${team.color}`,
+            )}
+          ></div>
+          <div
+            className={classNames(
+              "square",
+              "second-square",
+              `square--${team.color}`,
+            )}
+          ></div>
+          <div
+            className={classNames(
+              "square",
+              "third-square",
+              `square--${team.color}`,
+            )}
+          ></div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/signup/TeamsInfo.ts
+++ b/src/components/signup/TeamsInfo.ts
@@ -1,0 +1,42 @@
+type TeamInfo = Array<{
+  img: string;
+  name: string;
+  color: string;
+}>;
+
+export const TEAMS_INFO: TeamInfo = [
+  { img: "/images/tigers.svg", name: "기아 타이거즈", color: "tigers" },
+  { img: "/images/lions.svg", name: "삼성 라이온즈", color: "lions" },
+  { img: "/images/twins.svg", name: "LG 트윈스", color: "twins" },
+  { img: "/images/bears.svg", name: "두산 베어스", color: "bears" },
+  {
+    img: "/images/giants.svg",
+    name: "롯데 자이언츠",
+    color: "giants",
+  },
+  {
+    img: "/images/dinos.svg",
+    name: "NC 다이노스",
+    color: "dinos",
+  },
+  {
+    img: "/images/landers.svg",
+    name: "SSG 랜더스",
+    color: "landers",
+  },
+  {
+    img: "/images/wiz.svg",
+    name: "KT 위즈",
+    color: "wiz",
+  },
+  {
+    img: "/images/eagles.svg",
+    name: "한화 이글스",
+    color: "eagles",
+  },
+  {
+    img: "/images/heroes.svg",
+    name: "키움 히어로즈",
+    color: "heroes",
+  },
+];

--- a/src/lib/store/signup/store.ts
+++ b/src/lib/store/signup/store.ts
@@ -8,7 +8,8 @@ interface StepState {
 
 const useStore = create<StepState>((set) => ({
   signUpStep: 1,
-  increaseStep: () => set((state) => ({ signUpStep: state.signUpStep + 1 })),
+  increaseStep: () =>
+    set((state) => ({ signUpStep: Math.min(2, state.signUpStep + 1) })),
   decreaseStep: () =>
     set((state) => ({ signUpStep: Math.max(1, state.signUpStep - 1) })),
 }));

--- a/src/lib/store/signup/store.ts
+++ b/src/lib/store/signup/store.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+
+interface StepState {
+  signUpStep: number;
+  increaseStep: () => void;
+  decreaseStep: () => void;
+}
+
+const useStore = create<StepState>((set) => ({
+  signUpStep: 1,
+  increaseStep: () => set((state) => ({ signUpStep: state.signUpStep + 1 })),
+  decreaseStep: () =>
+    set((state) => ({ signUpStep: Math.max(1, state.signUpStep - 1) })),
+}));
+
+export default useStore;

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -17,6 +17,8 @@ $login-text: #f8f8f8;
 $login-obj: #383d46;
 $like-bg: #3e434b;
 $like-obj: #b3b3b3;
+$signup-back: #292b2e;
+$signup-border: #45484d;
 
 // 삼성라이온즈
 $lions1: #0264b3;

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -13,6 +13,7 @@ $gray: #252729;
 $dark-text1: #767b87;
 $dark-text2: #fff;
 $login-bg: #b9c4d9;
+$login-text: #f8f8f8;
 $login-obj: #383d46;
 $like-bg: #3e434b;
 $like-obj: #b3b3b3;


### PR DESCRIPTION
### 📌 개요

로그인 페이지와 연동되는 Signup 페이지의 ui를 생성합니다.
중간 PR입니다.

### ✅ 작업내용

![스크린샷 2024-01-30 오전 12 38 44](https://github.com/Team-TMB/client/assets/128357188/031f856d-a04e-4f36-90c7-ca9983baf7c5)
![스크린샷 2024-01-30 오전 12 38 35](https://github.com/Team-TMB/client/assets/128357188/70f9e460-f26b-47d4-a430-59141cc1ae13)

- 카드 호버 액션 있습니다, 선택시 애니메이션이나 효과는 미적용되었습니다.
- 추후 반응형 애니메이션 등의 추가가 있을 수 있어 카드 백그라운드의 그라데이션 박스를 div로 생성했습니다.
- `zustatnd`를 이용하여 버튼 카운트를 만들고, 그에 따라 signup이라는 한 페이지 안에서 스텝 컴포넌트가 변경되어 보이도록 했습니다.

### 📝 공유사항

- 아직 개발 중에 있습니다 🙇🏻‍♀️
- `SignupTeamCard.tsx` 팀 카드 컴포넌트를 통해 마이페이지나 팀 카드가 필요한 다른 곳에서도 사용 할 수 있게 개발 중입니다.
