### PR TITLE
[Feature] modal 커스텀 훅 생성

### DIFF
--- a/public/images/modalcloseicon.svg
+++ b/public/images/modalcloseicon.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 19.98L19.98 3" stroke="#A0A5B5" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.98 19.98L3 3" stroke="#A0A5B5" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Header from "@/components/common/Header";
 import { ReactNode } from "react";
 import "@/styles/GlobalStyles.scss";
 import { QueryClient, QueryClientProvider } from "react-query";
+import Modal from "@/components/common/Modal";
 
 const queryClient = new QueryClient();
 
@@ -13,6 +14,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <html lang="ko">
         <body>
           <QueryClientProvider client={queryClient}>
+            <Modal />
             <Header />
             <div>{children}</div>
           </QueryClientProvider>

--- a/src/components/common/Modal.scss
+++ b/src/components/common/Modal.scss
@@ -1,7 +1,9 @@
 @import "@/styles/colors.scss";
 .modal-block {
   position: fixed;
-  z-index: 999;
+  top: 0;
+  left: 0;
+  z-index: 9999;
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.4);

--- a/src/components/common/Modal.scss
+++ b/src/components/common/Modal.scss
@@ -1,0 +1,26 @@
+@import "@/styles/colors.scss";
+.modal-block {
+  position: fixed;
+  z-index: 999;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  .modal-content {
+    background-color: $gray;
+    border-radius: 20px;
+    width: 640px;
+    padding: 45px 68px;
+    position: absolute;
+
+    &__close {
+      text-align: right;
+      margin-bottom: 15px;
+      img {
+        cursor: pointer;
+      }
+    }
+  }
+}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import "@/components/common/Modal.scss";
+import { useModal } from "@/lib/hooks/useModal";
+import Image from "next/image";
+
+function Modal() {
+  const { modalData, closeModal } = useModal();
+
+  const handleOnClickClose = () => {
+    console.log(modalData);
+    closeModal();
+  };
+  return (
+    <>
+      {modalData.isOpen && (
+        <section className="modal-block">
+          <div className="modal-content">
+            <div className="modal-content__close">
+              <Image
+                src={"/images/modalcloseicon.svg"}
+                width={24}
+                height={24}
+                alt={"deleteicon"}
+                onClick={handleOnClickClose}
+              />
+            </div>
+            <div className="modal-content__detail">{modalData.content}</div>
+          </div>
+        </section>
+      )}
+    </>
+  );
+}
+
+export default Modal;

--- a/src/lib/hooks/useModal.ts
+++ b/src/lib/hooks/useModal.ts
@@ -1,0 +1,23 @@
+import { useCallback } from "react";
+import modalState from "@/lib/store/modalState";
+
+interface ModalDataState {
+  isOpen?: boolean;
+  content: JSX.Element | string;
+}
+
+export const useModal = () => {
+  const { modalData, setModalDataState } = modalState();
+
+  const closeModal = useCallback(
+    () => setModalDataState({ ...modalData, isOpen: false }),
+    [modalData, setModalDataState],
+  );
+
+  const openModal = useCallback(
+    (prop: ModalDataState) => setModalDataState({ ...prop, isOpen: true }),
+    [setModalDataState],
+  );
+
+  return { modalData, closeModal, openModal };
+};

--- a/src/lib/store/modalState.ts
+++ b/src/lib/store/modalState.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+
+interface ModalDataState {
+  isOpen?: boolean;
+  content: JSX.Element | string;
+}
+
+interface ModalState {
+  modalData: ModalDataState;
+  setModalDataState: (state: ModalDataState) => void;
+}
+
+const modalState = create<ModalState>((set) => ({
+  modalData: {
+    isOpen: false,
+    content: "",
+  },
+  setModalDataState: (state) =>
+    set((prev) => ({
+      modalData: { ...prev.modalData, ...state },
+    })),
+}));
+
+export default modalState;


### PR DESCRIPTION
### 📌 개요

closed #44
모달 커스텀 훅을 작성합니다.

### ✅ 작업내용

- zustand를 통해 전역으로 모달의 상태를 관리합니다.
- 커스텀 훅을 제작하여 open, close를 용이하게 합니다.
- modal 기본 컴포넌트 내에서 틀 스타일링은 완료되었습니다.
    - 닫기 버튼과 close 로직 처리 되어있습니다. 
    - 배경 어둡게 처리해두었습니다.

### 📝 공유사항

openModal 사용시
- 내용이 될 모달의 컴포넌트 자체를 content로 보내주시면 됩니다.

문제사항!
<img width="1118" alt="스크린샷 2024-02-17 오전 1 14 30" src="https://github.com/Team-TMB/client/assets/128357188/73f99eaf-1ed4-4f1c-af50-28c006c7abda">
- 헤더가 모달보다 앞에 있어 수정이 필요합니다.
    - 둘 다 sticky이고, z-index를 헤더보다 모달에 더 큰 숫자를 부여해도 상황이 같습니다. 