### PR TITLE
[Bug] 서브메뉴 위치 승부예측 바로 아래로 고정

### DIFF
--- a/src/components/common/Header.scss
+++ b/src/components/common/Header.scss
@@ -1,6 +1,6 @@
 @import "@/styles/colors.scss";
 
-.header-block {
+.header {
   width: 100%;
   height: 90px;
   background: $header;
@@ -13,7 +13,7 @@
   left: 0;
   z-index: 999;
 
-  &__content {
+  &__block {
     width: 1200px;
     height: inherit;
     display: flex;
@@ -22,27 +22,40 @@
     z-index: 999;
   }
 
-  &__navigation {
+  .navigation {
+    height: inherit;
     display: flex;
     justify-content: center;
-    align-self: flex-end;
-    div {
+    align-items: center;
+
+    &__list {
       display: flex;
+      justify-content: center;
+      align-items: center;
       gap: 160px;
+      height: 100%;
+    }
+
+    &__item {
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-size: 24px;
       .pagelink {
         color: $dark-text1;
         display: flex;
         flex-direction: column;
         align-items: center;
         gap: 24px;
-        font-size: 24px;
-        padding: 0 16px;
         &--active {
           color: $dark-text2;
           font-weight: 600;
         }
       }
       .underbar {
+        position: absolute;
+        bottom: 0;
         visibility: hidden;
         width: 50px;
         height: 8px;
@@ -58,7 +71,7 @@
 
 .profile {
   display: flex;
-  justify-content: center;
+  justify-content: right;
   align-items: center;
   gap: 12px;
   font-weight: 500;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -33,8 +33,8 @@ function Header() {
 
   return (
     <>
-      <header className="header-block">
-        <div className="header-block__content">
+      <header className="header">
+        <div className="header__block">
           <h1>
             <Link href={PATH.today}>
               <Image
@@ -46,25 +46,30 @@ function Header() {
               />
             </Link>
           </h1>
-          <nav className="header-block__navigation">
-            <div>
-              <Link
-                href={PATH.today}
-                className={`pagelink ${ACTIVE_MATCH_CLASSNAME}`}
-              >
-                승부예측
-                <div className={`underbar ${UNDERBAR_MATCH_CLASSNAME}`} />
-              </Link>
-              <Link
-                href={PATH.community}
-                className={`pagelink ${ACTIVE_COMMUNITY_CLASSNAME}`}
-              >
-                커뮤니티
-                <div
-                  className={`underbar ${UNDERBAR_COMMUNITY_CLASSNAME}`}
-                ></div>
-              </Link>
-            </div>
+          <nav className="navigation">
+            <ol className="navigation__list">
+              <li className="navigation__item">
+                {isSubMenuRequired && <SubMenu />}
+                <Link
+                  href={PATH.today}
+                  className={`pagelink ${ACTIVE_MATCH_CLASSNAME}`}
+                >
+                  승부예측
+                  <div className={`underbar ${UNDERBAR_MATCH_CLASSNAME}`} />
+                </Link>
+              </li>
+              <li className="navigation__item">
+                <Link
+                  href={PATH.community}
+                  className={`pagelink ${ACTIVE_COMMUNITY_CLASSNAME}`}
+                >
+                  커뮤니티
+                  <div
+                    className={`underbar ${UNDERBAR_COMMUNITY_CLASSNAME}`}
+                  ></div>
+                </Link>
+              </li>
+            </ol>
           </nav>
           {localNick ? (
             <Link href={PATH.mypage} className="profile">
@@ -95,7 +100,7 @@ function Header() {
                   className="profile__logo__basictitle"
                   src="/images/logo.svg"
                   alt="프로필이미지 로고"
-                  width={25}
+                  width={20}
                   height={5}
                 />
               </div>
@@ -103,7 +108,6 @@ function Header() {
             </Link>
           )}
         </div>
-        {isSubMenuRequired && <SubMenu />}
       </header>
       <div className="space" />
     </>

--- a/src/components/common/SubMenu.scss
+++ b/src/components/common/SubMenu.scss
@@ -1,69 +1,62 @@
 @import "@/styles/colors.scss";
+@import "@/styles/animation.scss";
 
-.submenu-block {
-  width: 100%;
+.submenu {
   height: 50px;
+  overflow: hidden;
   position: absolute;
-  z-index: 998;
   top: 90px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: $dark-bg;
-
-  a {
-    color: $dark-text1;
+  &__block {
+    left: 0;
+    width: 500px;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    font-size: 16px;
   }
 
-  &__content {
+  &__list {
+    width: 100%;
     display: flex;
-    gap: 60px;
-    position: relative;
-    left: -76px;
-    top: 6px;
+    transition: 0.2s;
   }
 
   &__item {
     text-align: center;
     cursor: pointer;
-  }
-}
-
-.scrollDown {
-  transition: opacity 0.2s ease-in-out;
-  animation: scrollDown 0.2s normal;
-  opacity: 0;
-  transform: translateY(-70px);
-  @keyframes scrollDown {
-    0% {
-      transform: translateY(0);
+    flex: 1 1 0;
+    a {
+      color: $dark-text1;
     }
-    100% {
-      transform: translateY(-20px);
+    .active {
+      font-weight: 600;
+      border-bottom: 4px solid #fff;
+      padding-bottom: 6px;
+      color: #fff;
     }
   }
+  &__bg {
+    position: fixed;
+    left: 0;
+    top: 90px;
+    background-color: $dark-bg;
+    width: 100vw;
+    height: 50px;
+    opacity: 0;
+    transition: 0.2s;
+    &--active {
+      opacity: 1;
+    }
+  }
 }
-
-.scrollUp {
-  transition: opacity 0.2s ease-in-out;
-  animation: scrollUp 0.2s normal;
+.scrolldown {
   opacity: 1;
   transform: translateY(0);
-  @keyframes scrollUp {
-    0% {
-      transform: translateY(-20px);
-    }
-    100% {
-      transform: translateY(0);
-    }
-  }
+  animation: drop-down 0.2s;
 }
-
-.active {
-  font-weight: 600;
-  border-bottom: 4px solid #fff;
-  padding-bottom: 6px;
-  a {
-    color: #fff;
-  }
+.scrollup {
+  transition: 0.2s;
+  opacity: 0;
+  transform: translateY(-50px);
+  animation: drop-up 0.2s;
 }

--- a/src/components/common/SubMenu.tsx
+++ b/src/components/common/SubMenu.tsx
@@ -1,9 +1,7 @@
-"use client";
-
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
 import "./SubMenu.scss";
+import { useCallback, useEffect, useState } from "react";
 
 function SubMenu() {
   const [position, setPosition] = useState(0);
@@ -25,31 +23,37 @@ function SubMenu() {
   }, [onScroll]);
 
   return (
-    <ul className={`submenu-block ${visible ? "scrollUp" : "scrollDown"}`}>
-      <ul className="submenu-block__content">
-        <li
-          className={`submenu-block__item ${
-            pathname === "/match/previous" ? "active" : ""
-          }`}
-        >
-          <Link href="/match/previous">지난예측</Link>
-        </li>
-        <li
-          className={`submenu-block__item ${
-            pathname === "/match/month" ? "active" : ""
-          }`}
-        >
-          <Link href="/match/month">월간 승리요정</Link>
-        </li>
-        <li
-          className={`submenu-block__item ${
-            pathname === "/match/today" ? "active" : ""
-          }`}
-        >
-          <Link href="/match/today">오늘의 승부예측</Link>
-        </li>
-      </ul>
-    </ul>
+    <div className="submenu">
+      <div className={`submenu__bg ${visible && "submenu__bg--active"}`}></div>
+      <div className="submenu__block">
+        <ul className={`submenu__list ${visible ? "scrolldown" : "scrollup"}`}>
+          <li className={"submenu__item"}>
+            <Link
+              href="/match/previous"
+              className={` ${pathname === "/match/previous" && "active"}`}
+            >
+              지난예측
+            </Link>
+          </li>
+          <li className={"submenu__item"}>
+            <Link
+              href="/match/month"
+              className={` ${pathname === "/match/month" && "active"}`}
+            >
+              월간 승리요정
+            </Link>
+          </li>
+          <li className={"submenu__item"}>
+            <Link
+              href="/match/today"
+              className={` ${pathname === "/match/today" && "active"}`}
+            >
+              오늘의 승부예측
+            </Link>
+          </li>
+        </ul>
+      </div>
+    </div>
   );
 }
 

--- a/src/styles/animation.scss
+++ b/src/styles/animation.scss
@@ -16,6 +16,24 @@
   }
 }
 
+@keyframes drop-down {
+  0% {
+    transform: translateY(-200%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes drop-up {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(-200%);
+  }
+}
+
 @keyframes pass-away {
   from {
     transform: translateX(0);


### PR DESCRIPTION
### 📌 개요

closed #76 
서브메뉴의 위치를 승부예측 밑으로 수정합니다.

### ✅ 작업내용

- 헤더, 서브메뉴 코드 변경이 있습니다.

해결
-  서브메뉴의 기준점을 승부예측으로 잡기 위해 div로 묶어주었습니다.
- 서브메뉴의 위치를 승부예측 아래로 고정시키고, 닉네임이 길어지거나 줄어들어서 승부예측의 위치가 바뀐다고 해도 서브메뉴가 따라서 움직입니다.

<img width="1401" alt="스크린샷 2024-03-14 오후 4 38 44" src="https://github.com/Team-TMB/client/assets/128357188/3de0d4a6-db78-4be5-a421-37a078e36372">
<img width="1417" alt="스크린샷 2024-03-14 오후 4 37 48" src="https://github.com/Team-TMB/client/assets/128357188/a0aa5c32-2ed4-431c-a9a7-4f015dd135d8">
