### PR TITLE
[Bug] 프로필 이미지 출력

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,9 @@
 /** @type {import('next').NextConfig} */
+
+const imageDomains = process.env.NEXT_PUBLIC_IMAGE_URL
+  ? process.env.NEXT_PUBLIC_IMAGE_URL.split("/")[2]
+  : [];
+
 const nextConfig = {
   async rewrites() {
     return [
@@ -16,6 +21,10 @@ const nextConfig = {
         permanent: false,
       },
     ];
+  },
+
+  images: {
+    domains: [imageDomains],
   },
 };
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 
 const imageDomains = process.env.NEXT_PUBLIC_IMAGE_URL
-  ? process.env.NEXT_PUBLIC_IMAGE_URL.split("/")[2]
+  ? new URL(process.env.NEXT_PUBLIC_IMAGE_URL).hostname
   : [];
 
 const nextConfig = {

--- a/src/components/common/Header.scss
+++ b/src/components/common/Header.scss
@@ -77,6 +77,9 @@
   font-weight: 500;
   font-size: 24px;
   &__logo {
+    position: relative;
+    overflow: hidden;
+    object-fit: contain;
     width: 38px;
     height: 38px;
     background: $signup-back;

--- a/src/components/common/Header.scss
+++ b/src/components/common/Header.scss
@@ -12,6 +12,7 @@
   top: 0;
   left: 0;
   z-index: 999;
+  border-bottom: 1.6px solid $dark-bg;
 
   &__block {
     width: 1200px;
@@ -79,7 +80,6 @@
   &__logo {
     position: relative;
     overflow: hidden;
-    object-fit: contain;
     width: 38px;
     height: 38px;
     background: $signup-back;
@@ -87,6 +87,9 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    img {
+      object-fit: cover;
+    }
     &__basictitle {
       height: 10px;
       text-align: center;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -85,9 +85,8 @@ function Header() {
                 ) : (
                   <Image
                     alt="profileimg"
-                    src={`${localURL}`}
-                    width={24}
-                    height={24}
+                    src={`${process.env.NEXT_PUBLIC_IMAGE_URL}${localURL}`}
+                    fill={true}
                   />
                 )}
               </div>

--- a/src/components/mypage/MypageProfile.scss
+++ b/src/components/mypage/MypageProfile.scss
@@ -66,8 +66,14 @@
     }
     &__img {
       @include box-default;
+      position: relative;
+      overflow: hidden;
+      object-fit: cover;
       width: 212px;
       height: 260px;
+      img {
+        object-fit: cover;
+      }
     }
     &__line {
       @include box-default;

--- a/src/components/mypage/MypageProfile.tsx
+++ b/src/components/mypage/MypageProfile.tsx
@@ -38,8 +38,13 @@ function MypageProfile() {
         <div className="profile-box__content detail-box">
           <div className="detail-box__block">
             <div className="detail-box__img">
-              {/* <Image src={profileData.profileImageUrl} /> */}
-              이미지 추가예정 수정도 아직 안됩니다,,,
+              {profileData && (
+                <Image
+                  src={`${process.env.NEXT_PUBLIC_IMAGE_URL}${profileData.profileImageUrl}`}
+                  alt="프로필사진"
+                  fill={true}
+                />
+              )}
             </div>
             <ol className="detail-box__list">
               <li className="detail-box__item">

--- a/src/components/mypage/MypageSection.tsx
+++ b/src/components/mypage/MypageSection.tsx
@@ -7,7 +7,7 @@ function MyPageSection() {
   return (
     <section className="mypage">
       <div className="mypage__btn">
-        <Button label="수정" size="small" variant="primary" />
+        <Button label="수정" size="x-medium" variant="primary" />
       </div>
       <MypageProfile />
       <MypageMenu />


### PR DESCRIPTION
### 📌 개요

closed #82
로그인 이후 프로필 url 값을 이미지 서버와 연결하고 출력합니다.

### ✅ 작업내용
<img width="1653" alt="스크린샷 2024-03-19 오후 3 46 08" src="https://github.com/Team-TMB/client/assets/128357188/d0f76a02-b2cc-4a6e-a529-9e8d09158274">

### 환경변수 생성
- 환경 변수를 생성하고 이를 통해 주소에 접근합니다.
- next.config.js 설정
    - next.js <Image> 컴포넌트에서 서버 주소에 접근하기 위해서 domain을 추가해줍니다. 
```
const imageDomains = process.env.NEXT_PUBLIC_IMAGE_URL
  ? new URL(process.env.NEXT_PUBLIC_IMAGE_URL).hostname
  : [];

  images: {
    domains: [imageDomains],
  },
  ```
### 이미지 처리
- 이미지 컴포넌트의 fill 값을 true로 설정하고, css설정으로 `object-fit: cover;`를 설정하여 비율을 고정한 채로 컨테이너에 꽉 채울 수 있게 설정합니다.

### 📝 공유사항

환경변수에 디스코드로 전달드린 주소를 추가해주세요!
