### PR TITLE
[Feat] 채팅 프로필 조회, 토큰 선물 api 연결

### DIFF
--- a/src/components/chat/ChatSection.tsx
+++ b/src/components/chat/ChatSection.tsx
@@ -11,12 +11,16 @@ import ChatInput from "@/components/chat/ChatInput";
 import useMenuModalState from "@/lib/store/chat/menuModalState";
 import VoteModal from "@/components/chat/modals/VoteModal";
 import { useSocket } from "@/lib/hooks/useSocket";
-import { useStompShoutData } from "@/lib/store/chat/stompclientStore";
+import {
+  useStompClient,
+  useStompShoutData,
+} from "@/lib/store/chat/stompclientStore";
 import ShoutBubble from "@/components/chat/chatlog/ShoutBubble";
 
 function ChatSection() {
   const ROOMNUM = 1; //TODO: NextJS url praram
 
+  const { stompClient } = useStompClient();
   const { connectSocket } = useSocket();
   const { menuModalState } = useMenuModalState();
   const { shoutData } = useStompShoutData();
@@ -24,6 +28,12 @@ function ChatSection() {
 
   useEffect(() => {
     connectSocket(ROOMNUM);
+
+    return () => {
+      if (stompClient) {
+        stompClient.deactivate();
+      }
+    };
   }, []);
 
   return (

--- a/src/components/chat/chatlog/ChatBubble.tsx
+++ b/src/components/chat/chatlog/ChatBubble.tsx
@@ -10,7 +10,7 @@ function ChatBubble({ data }: { data: MessageType }) {
 
   const onClickNickname = () => {
     openModal({
-      content: <ProfileModal />,
+      content: <ProfileModal nickname={data.profile.nickname} />,
     });
   };
   return (

--- a/src/components/chat/modals/PresentModal.scss
+++ b/src/components/chat/modals/PresentModal.scss
@@ -1,0 +1,39 @@
+@import "@/styles/colors.scss";
+
+.presentmodal {
+  &__block {
+  }
+  &__content {
+    &:first-child {
+      margin-bottom: 18px;
+    }
+  }
+  &__title {
+    font-size: 14px;
+    color: #969696;
+  }
+  &__inputbox {
+    margin-top: 10px;
+    width: 316px;
+    height: 54px;
+    background-color: $surface;
+    border-radius: 10px;
+    padding: 0 36px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  &__input {
+    font-size: 14px;
+    color: white;
+    background-color: transparent;
+    border: none;
+    &:focus {
+      outline: none;
+    }
+  }
+  &__desc {
+    font-size: 14px;
+    color: #818a99;
+  }
+}

--- a/src/components/chat/modals/PresentModal.scss
+++ b/src/components/chat/modals/PresentModal.scss
@@ -28,6 +28,7 @@
     color: white;
     background-color: transparent;
     border: none;
+    width: 100%;
     &:focus {
       outline: none;
     }
@@ -35,5 +36,6 @@
   &__desc {
     font-size: 14px;
     color: #818a99;
+    margin-left: 10px;
   }
 }

--- a/src/components/chat/modals/PresentModal.tsx
+++ b/src/components/chat/modals/PresentModal.tsx
@@ -1,8 +1,12 @@
 import "@/components/chat/modals/PresentModal.scss";
-import Button from "@/components/common/Button";
 import TokenButton from "./TokenButton";
 
-function PresentModal() {
+type PropType = {
+  onChangeMessage: (e) => void;
+  onChangeTokenNumber: (e) => void;
+};
+
+function PresentModal({ onChangeMessage, onChangeTokenNumber }: PropType) {
   return (
     <section className="presentmodal">
       <div className="presentmodal__block">
@@ -13,6 +17,8 @@ function PresentModal() {
               type="text"
               placeholder="어떤 메세지를 함께 보낼까?"
               className="presentmodal__input"
+              onChange={onChangeMessage}
+              maxLength={30}
             />
           </div>
         </div>
@@ -20,16 +26,16 @@ function PresentModal() {
           <p className="presentmodal__title">토큰 선물</p>
           <div className="presentmodal__inputbox">
             <input
-              type="text"
+              type="number"
               placeholder="몇 토큰을 선물할래?"
               className="presentmodal__input"
+              onChange={onChangeTokenNumber}
             />
             <div className="presentmodal__desc">tk</div>
           </div>
         </div>
       </div>
       <TokenButton />
-      <Button label="선물하기" size="large" variant="active" />
     </section>
   );
 }

--- a/src/components/chat/modals/PresentModal.tsx
+++ b/src/components/chat/modals/PresentModal.tsx
@@ -4,12 +4,33 @@ import TokenButton from "./TokenButton";
 
 function PresentModal() {
   return (
-    <>
-      <div>모달선물</div>
-      <input type="text" />
+    <section className="presentmodal">
+      <div className="presentmodal__block">
+        <div className="presentmodal__content">
+          <p className="presentmodal__title">한줄 메세지</p>
+          <div className="presentmodal__inputbox">
+            <input
+              type="text"
+              placeholder="어떤 메세지를 함께 보낼까?"
+              className="presentmodal__input"
+            />
+          </div>
+        </div>
+        <div className="presentmodal__content">
+          <p className="presentmodal__title">토큰 선물</p>
+          <div className="presentmodal__inputbox">
+            <input
+              type="text"
+              placeholder="몇 토큰을 선물할래?"
+              className="presentmodal__input"
+            />
+            <div className="presentmodal__desc">tk</div>
+          </div>
+        </div>
+      </div>
       <TokenButton />
       <Button label="선물하기" size="large" variant="active" />
-    </>
+    </section>
   );
 }
 

--- a/src/components/chat/modals/PresentModal.tsx
+++ b/src/components/chat/modals/PresentModal.tsx
@@ -2,8 +2,8 @@ import "@/components/chat/modals/PresentModal.scss";
 import TokenButton from "./TokenButton";
 
 type PropType = {
-  onChangeMessage: (e) => void;
-  onChangeTokenNumber: (e) => void;
+  onChangeMessage: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChangeTokenNumber: (e: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 function PresentModal({ onChangeMessage, onChangeTokenNumber }: PropType) {

--- a/src/components/chat/modals/ProfileModal.scss
+++ b/src/components/chat/modals/ProfileModal.scss
@@ -1,0 +1,9 @@
+.profilemodal {
+  &__contents {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 26px;
+  }
+}

--- a/src/components/chat/modals/ProfileModal.tsx
+++ b/src/components/chat/modals/ProfileModal.tsx
@@ -50,7 +50,7 @@ function ProfileModal({ nickname }: { nickname: string }) {
         </Title>
       </div>
       <Button
-        size="medium"
+        size={"medium"}
         variant="active"
         label="선물하기"
         onClick={onClickPresent}

--- a/src/components/chat/modals/ProfileModal.tsx
+++ b/src/components/chat/modals/ProfileModal.tsx
@@ -2,24 +2,60 @@ import "@/components/chat/modals/ProfileModal.scss";
 import Button from "@/components/common/Button";
 import { useModal } from "@/lib/hooks/useModal";
 import PresentModal from "./PresentModal";
+import { getProfile } from "@/lib/api/chatAPI";
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import Title from "@/components/common/Title";
 
-function ProfileModal() {
+type ProfileModal = {
+  nickname: string;
+  profileImageUrl: string;
+  winFairyCount: number;
+  loseFairyCount: number;
+};
+
+function ProfileModal({ nickname }: { nickname: string }) {
   const { openModal } = useModal();
+  const [profileData, setProfileData] = useState<ProfileModal>();
+
+  useEffect(() => {
+    const getProfileData = async () => {
+      const res = await getProfile(nickname);
+      setProfileData(res.data);
+    };
+    getProfileData();
+  }, []);
+
   const onClickPresent = () => {
     openModal({
       content: <PresentModal />,
     });
   };
   return (
-    <>
-      <div>프로필 클릭</div>
+    <section className="profilemodal">
+      <div className="profilemodal__contents">
+        <Image
+          className="profilemodal__img"
+          width={40}
+          height={40}
+          alt="profileImage"
+          src={
+            profileData
+              ? `${process.env.NEXT_PUBLIC_IMAGE_URL}${profileData.profileImageUrl}`
+              : "/images/logo.svg"
+          }
+        />
+        <Title small className="profilemodal__title">
+          {profileData && profileData.nickname}
+        </Title>
+      </div>
       <Button
         size="medium"
         variant="active"
         label="선물하기"
         onClick={onClickPresent}
       />
-    </>
+    </section>
   );
 }
 

--- a/src/components/chat/modals/ProfileModal.tsx
+++ b/src/components/chat/modals/ProfileModal.tsx
@@ -42,7 +42,7 @@ function ProfileModal({ nickname }: { nickname: string }) {
     return;
   };
 
-  const onChangeMessage = (e) => {
+  const onChangeMessage = (e: React.ChangeEvent<HTMLInputElement>) => {
     const comment = e.target.value;
     setTokenBody((prev) => ({
       ...prev,
@@ -50,7 +50,7 @@ function ProfileModal({ nickname }: { nickname: string }) {
     }));
   };
 
-  const onChangeTokenNumber = (e) => {
+  const onChangeTokenNumber = (e: React.ChangeEvent<HTMLInputElement>) => {
     const tokenNumber = Number(e.target.value);
     setTokenBody((prev) => ({
       ...prev,

--- a/src/components/chat/modals/TokenButton.scss
+++ b/src/components/chat/modals/TokenButton.scss
@@ -11,4 +11,5 @@
   gap: 10px;
   align-items: center;
   padding: 0 6px;
+  margin: 10px 0;
 }

--- a/src/components/chat/modals/TokenButton.tsx
+++ b/src/components/chat/modals/TokenButton.tsx
@@ -1,11 +1,26 @@
 import "@/components/chat/modals/TokenButton.scss";
+import { getProfileDetails } from "@/lib/api/mypageAPI";
+import { useEffect, useState } from "react";
 
 //todo: token값 api값 연동
 function TokenButton() {
+  const [token, setToken] = useState<number>(0);
+  useEffect(() => {
+    const getToken = async () => {
+      try {
+        const res = await getProfileDetails();
+        setToken(res.data.token);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    getToken();
+  }, []);
+
   return (
     <div className="token__block">
       <p>💰 내 토큰</p>
-      <p>3tk</p>
+      <p>{token}tk</p>
     </div>
   );
 }

--- a/src/components/chat/modals/TokenButton.tsx
+++ b/src/components/chat/modals/TokenButton.tsx
@@ -1,15 +1,18 @@
 import "@/components/chat/modals/TokenButton.scss";
 import { getProfileDetails } from "@/lib/api/mypageAPI";
+import useTokenNumberStore from "@/lib/store/chat/tokenStore";
 import { useEffect, useState } from "react";
 
 //todo: token값 api값 연동
 function TokenButton() {
   const [token, setToken] = useState<number>(0);
+  const { setTotalStore } = useTokenNumberStore();
   useEffect(() => {
     const getToken = async () => {
       try {
         const res = await getProfileDetails();
         setToken(res.data.token);
+        setTotalStore(res.data.token);
       } catch (e) {
         console.error(e);
       }

--- a/src/lib/api/chatAPI.ts
+++ b/src/lib/api/chatAPI.ts
@@ -39,3 +39,12 @@ export const putToken = (body: TokenBody) => {
     console.error(error);
   }
 };
+
+export const getProfile = (nickname: string) => {
+  try {
+    const res = fetchData(`/profiles?nickname=${nickname}`, "get");
+    return res;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/lib/store/chat/tokenStore.ts
+++ b/src/lib/store/chat/tokenStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface UseTokenNumberStore {
+  totalStore: number;
+  setTotalStore: (num: number) => void;
+}
+
+const useTokenNumberStore = create<UseTokenNumberStore>((set) => ({
+  totalStore: 0,
+  setTotalStore: (num) => set({ totalStore: num }),
+}));
+
+export default useTokenNumberStore;


### PR DESCRIPTION
### 📌 개요

#81
채팅 모달 기능에 필요한 api를 연결합니다.

### ✅ 작업내용
<img width="1296" alt="스크린샷 2024-06-02 오후 6 43 56" src="https://github.com/Team-TMB/client/assets/128357188/b44382f8-ba90-42b9-a40c-58fc6cda5cef">
<img width="1296" alt="스크린샷 2024-06-02 오후 6 44 07" src="https://github.com/Team-TMB/client/assets/128357188/e877ca88-4c28-45d7-be6b-e67aa68f4dbb">

### 프로필 모달
- 프로필 조회 api를 연결합니다.
- 조회된 응답값을 모달에 보여주고, 선물하기 버튼을 누르면 토큰 선물로 이어집니다.
- 이후 모든 필요 값을 입력하고 요건이 충족되면 토큰 선물 api를 put합니다.

### 토큰 버튼
- 마이 프로필 조회 api를 연결하여 현재 토큰 갯수를 불러옵니다.
- 토큰 갯수를 store로 저장하여 토큰 갯수에 따라 버튼이 active/ disactive 될 때 처리합니다.

### 소켓 disactive
- 채팅 페이지 언마운트시 소켓을 disactive 합니다.
