### PR TITLE
!HOTFIX: 패배요정 1위 프로필 정보 출력 오류 수정

### DIFF
--- a/src/components/month/LoserMonthItem.tsx
+++ b/src/components/month/LoserMonthItem.tsx
@@ -57,7 +57,11 @@ function WinnerMonthItem({ monthData }: WinnerMonthItemProps) {
         </div>
         <div className="text-logo">
           {/* 추후 Image 컴포넌트로 변경 */}
-          <Profile imageUrl="" nickname="" size={60} />
+          <Profile
+            imageUrl=""
+            nickname={monthData?.loseMembers[0].nickname}
+            size={60}
+          />
           <div className="text">
             <Title large>
               {truncateNickname(monthData?.loseMembers[0].nickname, 6)}


### PR DESCRIPTION
### 📌 개요

<!-- PR과 관련있는 Issue를 closed 해주세요 -->

closed #0

작업한 내용에 대해 간단히 작성해주세요.

### ✅ 작업내용

- 패배요정 1위 프로필 이미지 클릭 시 프로필 정보 출력안되는 문제 긴급 수정

### 📝 공유사항

팀원들에게 공유할 사항이나 변경 사항들을 작성해주세요.

- ex) ooo라이브러리 설치했으니, npm install을 한번씩 해주세요!
